### PR TITLE
Issue #30, including a server url

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,16 @@
           "default": false,
           "description": "Only return Trivy results for vulnerabilities with fixes"
         },
+        "trivy.server.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Connect to a trivy server, on a remote machine"
+        },
+        "trivy.server.url": {
+          "type": "string",
+          "default": "",
+          "description": "The remote trivy URL to connect to"
+        },
         "trivy.minimumReportedSeverity": {
           "type": "string",
           "default": "UNKNOWN",

--- a/src/trivy_wrapper.ts
+++ b/src/trivy_wrapper.ts
@@ -144,6 +144,11 @@ export class TrivyWrapper {
             command.push('--ignore-unfixed');
         }
 
+        if (config.get<boolean>("server.enable")) {
+            command.push('--server');
+            command.push(`${config.get<string>("server.url")}`);
+        }
+
         
 
         command.push('--format=json');


### PR DESCRIPTION
### What
Added a config value that allows the user to enable a trivy client/server connection

### Why
Sometimes users want to be able to connect to a remote instance of trivy instead of running a local instance.

### How
Added two new config values
`server.enabled` and `server.url`. When building the command, we're now checking if the server.enabled option is checked, and if it is, inserting `--server ` with the URL provided, into the command.

### Anything Else
This is to address the following issue: https://github.com/aquasecurity/trivy-vscode-extension/issues/30
