### PR TITLE
Adding settings for Trivy --config

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,12 @@
         "trivy.configPath": {
           "type": "string",
           "default": "",
-          "description": "Path to Trivy non-default config file, --config."
+          "description": "Path to Trivy non-default config file via --config."
+        },
+        "trivy.configPathOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only use the config file. This DISABLES other settings in this extension."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
             "UNKNOWN"
           ],
           "description": "Return Trivy results with severity greater than or equal to this setting."
+        },
+        "trivy.configPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to Trivy non-default config file, --config."
         }
       }
     },

--- a/src/trivy_wrapper.ts
+++ b/src/trivy_wrapper.ts
@@ -135,11 +135,11 @@ export class TrivyWrapper {
             command.push(configPath);
         }
 
-        if (config.get<boolean>('configPathOnly')) {
+        if (!config.get<boolean>('configPathOnly')) {
             if (config.get<boolean>('debug')) {
                 command.push('--debug');
             }
-            
+
             command.push(this.getRequiredSeverities(config));
 
             if (config.get<boolean>("offlineScan")) {

--- a/src/trivy_wrapper.ts
+++ b/src/trivy_wrapper.ts
@@ -123,35 +123,37 @@ export class TrivyWrapper {
         const config = vscode.workspace.getConfiguration('trivy');
         var command = [];
 
-
-        if (config.get<boolean>('debug')) {
-            command.push('--debug');
-        }
-
         let requireChecks = "config,vuln";
         if (config.get<boolean>("secretScanning")) {
             requireChecks = `${requireChecks},secret`;
         }
         command.push("fs");
         command.push(`--security-checks=${requireChecks}`);
-        command.push(this.getRequiredSeverities(config));
-
-        if (config.get<boolean>("offlineScan")) {
-            command.push('--offline-scan');
-        }
-
-        if (config.get<boolean>("fixedOnly")) {
-            command.push('--ignore-unfixed');
-        }
-
-        if (config.get<boolean>("server.enable")) {
-            command.push('--server');
-            command.push(`${config.get<string>("server.url")}`);
-        }
 
         let configPath = this.getConfigPath(config);
         if (configPath) {
             command.push(configPath);
+        }
+
+        if (config.get<boolean>('configPathOnly')) {
+            if (config.get<boolean>('debug')) {
+                command.push('--debug');
+            }
+            
+            command.push(this.getRequiredSeverities(config));
+
+            if (config.get<boolean>("offlineScan")) {
+                command.push('--offline-scan');
+            }
+
+            if (config.get<boolean>("fixedOnly")) {
+                command.push('--ignore-unfixed');
+            }
+
+            if (config.get<boolean>("server.enable")) {
+                command.push('--server');
+                command.push(`${config.get<string>("server.url")}`);
+            }
         }
 
         command.push('--format=json');

--- a/src/trivy_wrapper.ts
+++ b/src/trivy_wrapper.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as child from 'child_process';
 import { v4 as uuid } from 'uuid';
 import * as path from 'path';
-import { unlinkSync, readdirSync } from 'fs';
+import { unlinkSync, readdirSync, existsSync } from 'fs';
 
 export class TrivyWrapper {
     private workingPath: string[] = [];
@@ -149,7 +149,10 @@ export class TrivyWrapper {
             command.push(`${config.get<string>("server.url")}`);
         }
 
-        
+        let configPath = this.getConfigPath(config);
+        if (configPath) {
+            command.push(configPath);
+        }
 
         command.push('--format=json');
         const resultsPath = path.join(this.resultsStoragePath, `${uuid()}_results.json`);
@@ -180,6 +183,16 @@ export class TrivyWrapper {
 
         return `--severity=${requiredSeverities.join(",")}`;
     }
+
+    private getConfigPath(config: vscode.WorkspaceConfiguration): string {
+
+        let configPathArg = "";
+
+        const configPath = config.get<string>("configPath") || "";
+        if (configPath && existsSync(configPath)) {
+            configPathArg = `--config=${configPath}`;
+        }
+
+        return configPathArg;
+    }
 }
-
-


### PR DESCRIPTION
- Allows the user to define a --config file.
- Allows the user to use only the config file, bypassing the other settings in the extension.

 Addresses the concerns in #42.