### PR TITLE
Fix '--security-checks' is deprecated. Use '--scanners' instead.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(
     "trivy-vulnerability-scanner.scan",
     () => {
-      const trivyScanCmd = "trivy --quiet filesystem --security-checks config,vuln --exit-code=10";
+      const trivyScanCmd = "trivy --quiet filesystem --scanners config,vuln --exit-code=10";
       var scanResult = runCommand(trivyScanCmd, projectRootPath.toString());
       if (scanResult.length > 0) {
         outputChannel.show();

--- a/src/trivy_wrapper.ts
+++ b/src/trivy_wrapper.ts
@@ -133,7 +133,7 @@ export class TrivyWrapper {
             requireChecks = `${requireChecks},secret`;
         }
         command.push("fs");
-        command.push(`--security-checks=${requireChecks}`);
+        command.push(`--scanners=${requireChecks}`);
         command.push(this.getRequiredSeverities(config));
 
         if (config.get<boolean>("offlineScan")) {


### PR DESCRIPTION
- Trivy v0.46.0
- VSCode v1.83.1
- VSCode extension v0.7.0

`Output` from `VSCode`:

```
Running Trivy to update results
command: fs,--security-checks=config,vuln,--severity=CRITICAL,HIGH,MEDIUM,--format=json,--output=/xxxx/xxxx/.vscode-server/data/User/workspaceStorage/xxxx/AquaSecurityOfficial.trivy-vulnerability-scanner/.trivy/xxxx_results.json,/xxxx/xxxx/xxxx
2023-10-18T21:34:31.165+0200	[33mWARN[0m	'--security-checks' is deprecated. Use '--scanners' instead.
```