### PR TITLE
bugfix: for secrets unable to dispaly complete list in treeview

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "A VS Code extension for Trivy.",
   "icon": "images/aqualogo.png",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "vscode": "^1.54.0"
   },

--- a/src/explorer/trivy_treeview.ts
+++ b/src/explorer/trivy_treeview.ts
@@ -110,7 +110,7 @@ export class TrivyTreeViewProvider implements vscode.TreeDataProvider<TrivyTreeI
 
 	getSecretInstances(element: TrivyTreeItem): TrivyTreeItem[] {
 		let results: TrivyTreeItem[] = [];
-		const filtered = this.resultData.filter(c => c.id === element.code && c.filename === element.filename);
+		const filtered = this.resultData.filter(c => c.filename === element.filename);
 
 		for (let index = 0; index < filtered.length; index++) {
 			const result = filtered[index];


### PR DESCRIPTION
We are able to identify the secrets in scanning, but while displying the treeview we are always getting first element in the list and displaying. Now this got fixed.

Before changes
![image](https://github.com/aquasecurity/trivy-vscode-extension/assets/10487510/c742399f-21d0-4c45-abd1-ea513ec13a7c)


After Changes
![image](https://github.com/aquasecurity/trivy-vscode-extension/assets/10487510/dad212cc-0543-4b78-8d79-9281fd693cfd)
