### PR TITLE
test: use same command builder for tests

### DIFF
--- a/src/command/options.ts
+++ b/src/command/options.ts
@@ -3,13 +3,11 @@ import * as vscode from 'vscode';
 // TrivyCommandOption is an interface that defines the structure of the TrivyCommandOption class.
 // The TrivyCommandOption class has an apply method that takes a command and a configuration and returns
 // the updated command.
-interface TrivyCommandOption {
-  name: string;
+export interface TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[];
 }
 
-class DebugOption implements TrivyCommandOption {
-  readonly name = 'debug';
+export class DebugOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -22,8 +20,7 @@ class DebugOption implements TrivyCommandOption {
   }
 }
 
-class ScannersOption implements TrivyCommandOption {
-  readonly name = 'scanners';
+export class ScannersOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -39,9 +36,7 @@ class ScannersOption implements TrivyCommandOption {
   }
 }
 
-class RequiredSeveritiesOption implements TrivyCommandOption {
-  readonly name = 'requiredSeverities';
-
+export class RequiredSeveritiesOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -74,9 +69,7 @@ class RequiredSeveritiesOption implements TrivyCommandOption {
   }
 }
 
-class OfflineScanOption implements TrivyCommandOption {
-  readonly name = 'offlineScan';
-
+export class OfflineScanOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -89,9 +82,7 @@ class OfflineScanOption implements TrivyCommandOption {
   }
 }
 
-class FixedOnlyOption implements TrivyCommandOption {
-  readonly name = 'fixedOnly';
-
+export class FixedOnlyOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     if (config.get<boolean>('fixedOnly')) {
       command.push('--ignore-unfixed');
@@ -101,9 +92,7 @@ class FixedOnlyOption implements TrivyCommandOption {
   }
 }
 
-class IgnoreFilePathOption implements TrivyCommandOption {
-  readonly name = 'useTrivyIgnoreFile';
-
+export class IgnoreFilePathOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -123,9 +112,7 @@ class IgnoreFilePathOption implements TrivyCommandOption {
   }
 }
 
-class ConfigFilePathOption implements TrivyCommandOption {
-  readonly name = 'configFilePath';
-
+export class ConfigFilePathOption implements TrivyCommandOption {
   apply(command: string[], config: vscode.WorkspaceConfiguration): string[] {
     // if onlyUseConfigFile is set, we don't need to add the scanners option
     if (config.get<boolean>('onlyUseConfigFile')) {
@@ -147,24 +134,34 @@ class ConfigFilePathOption implements TrivyCommandOption {
   }
 }
 
-export const TrivyCommandOptions: TrivyCommandOption[] = [
-  new ScannersOption(),
-  new ConfigFilePathOption(),
-  new RequiredSeveritiesOption(),
-  new OfflineScanOption(),
-  new FixedOnlyOption(),
-  new IgnoreFilePathOption(),
-  new DebugOption(),
-];
-
-export function getTrivyCommandOptions(
-  commandName: string
-): TrivyCommandOption {
-  const option = TrivyCommandOptions.find(
-    (option) => option.name === commandName
-  );
-  if (!option) {
-    throw new Error(`Unknown command option: ${commandName}`);
+export class JSONFormatOption implements TrivyCommandOption {
+  apply(command: string[]): string[] {
+    command.push('--format=json');
+    return command;
   }
-  return option;
+}
+
+export class ResultsOutputOption implements TrivyCommandOption {
+  constructor(private resultsPath: string) {}
+
+  apply(command: string[]): string[] {
+    command.push(`--output=${this.resultsPath}`);
+    return command;
+  }
+}
+
+export class ExitCodeOption implements TrivyCommandOption {
+  constructor(private exitCode: number) {}
+
+  apply(command: string[]): string[] {
+    command.push(`--exit-code=${this.exitCode}`);
+    return command;
+  }
+}
+
+export class QuietOption implements TrivyCommandOption {
+  apply(command: string[]): string[] {
+    command.push('--quiet');
+    return command;
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,44 +1,11 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { TrivyHelpProvider } from './explorer/trivy_helpview';
 import { TrivyTreeViewProvider } from './explorer/trivy_treeview';
 import { TrivyWrapper } from './command/trivy';
-import { execSync } from 'child_process';
-
-export function runCommand(command: string, projectRootPath: string): string {
-  try {
-    return execSync(command + ' ' + projectRootPath).toString();
-  } catch (result: any) {
-    switch (result.status) {
-      case 10: {
-        vscode.window.showErrorMessage(
-          'Trivy: Vulnerabilities found, check logs for details.'
-        );
-        return result.stdout.toString();
-      }
-      default: {
-        vscode.window.showErrorMessage(
-          'Failed to run Trivy scan, error: ' +
-            result.status +
-            ' check logs for details.'
-        );
-        return result.stdout.toString();
-      }
-    }
-  }
-}
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  // This line of code will only be executed once when your extension is activated
-  console.log(
-    'Congratulations, your extension "trivy-vulnerability-scanner" is now active!'
-  );
-
   const outputChannel = vscode.window.createOutputChannel('Trivy Scan');
 
   const projectRootPath = vscode.workspace.getWorkspaceFolder;

--- a/test/suite/command/options.test.ts
+++ b/test/suite/command/options.test.ts
@@ -1,7 +1,7 @@
 
 import * as assert from 'assert';
 import * as vscode from 'vscode'
-import { getTrivyCommandOptions } from '../../../src/command/options';
+import { DebugOption, FixedOnlyOption, IgnoreFilePathOption, OfflineScanOption, ScannersOption } from '../../../src/command/options';
 
 class mockConfig{
   private values: { [key: string]: boolean | string } = {
@@ -30,7 +30,7 @@ suite('trivy command options', function (): void {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('debug');
+    const commandOption = new DebugOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--debug');
@@ -40,7 +40,7 @@ suite('trivy command options', function (): void {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('scanners');
+    const commandOption = new ScannersOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--scanners=misconfig,vuln'); 
@@ -53,7 +53,7 @@ suite('trivy command options', function (): void {
 
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('scanners');
+    const commandOption = new ScannersOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--scanners=misconfig,vuln,secret');
@@ -64,7 +64,7 @@ suite('trivy command options', function (): void {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('offlineScan');
+    const commandOption = new OfflineScanOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--offline-scan');
@@ -74,7 +74,7 @@ suite('trivy command options', function (): void {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('fixedOnly');
+    const commandOption = new FixedOnlyOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--ignore-unfixed');
@@ -84,7 +84,7 @@ suite('trivy command options', function (): void {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
     let command : string[] = []
 
-    const commandOption = getTrivyCommandOptions('useTrivyIgnoreFile');
+    const commandOption = new IgnoreFilePathOption();
     command = commandOption.apply(command, config);
 
     assert.strictEqual(command.join(' '), '--ignorefile=.trivyignore.yaml');

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -1,12 +1,18 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import * as assert from 'assert';
 import * as fs from 'fs';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
+
+
 import * as vscode from 'vscode';
 
 import path from 'path';
-import *  as trivyExtension from  '../../src/extension'; // Adjust the import path as necessary
+import { TrivyWrapper } from '../../src/command/trivy';
+import { ExitCodeOption, QuietOption } from '../../src/command/options';
+import * as child from 'child_process';
 
 const testsRoot = path.resolve(__dirname, '..');
   
@@ -14,11 +20,46 @@ suite('extension', function (): void {
   this.timeout(10000); // Give the test 10 seconds to allow for the CI vscode to download
   vscode.window.showInformationMessage('Start all tests.');
 
-  test('Not a vulnerable project', () => {
-    const got = trivyExtension.runCommand(
-      'trivy --quiet filesystem --exit-code=10',
-      testsRoot + '/golden/not-vulnerable'
+  const runCommand = function(projectPath: string): string {
+    const targetDir = fs.mkdtempSync(projectPath);
+    const wrapper = new TrivyWrapper(
+      vscode.window.createOutputChannel('Trivy Scan'),
+      targetDir
     );
+
+    const commandArgs = wrapper.buildCommand(projectPath, [
+      new QuietOption(),
+      new ExitCodeOption(10)
+    ])
+    const command = `trivy ${commandArgs.join(' ')}`;
+  
+    console.log('Running command: ' + command);
+
+    try {
+      return child.execSync(command).toString();
+    } catch (result: any) {
+      switch (result.status) {
+        case 10: {
+          vscode.window.showErrorMessage(
+            'Trivy: Vulnerabilities found, check logs for details.'
+          );
+          return result.stdout.toString();
+        }
+        default: {
+          vscode.window.showErrorMessage(
+            'Failed to run Trivy scan, error: ' +
+              result.status +
+              ' check logs for details.'
+          );
+          return result.stdout.toString();
+        }
+      }
+    }  
+  return '';
+  }
+
+  test('Not a vulnerable project', () => {
+    const got = runCommand(testsRoot + '/golden/not-vulnerable');
     const expected = '';
     assert.strictEqual(
       got,
@@ -28,10 +69,7 @@ suite('extension', function (): void {
   });
 
   test('Vulnerable project', () => {
-    const got = trivyExtension.runCommand(
-      'trivy --quiet filesystem --exit-code=10',
-      testsRoot + '/golden/vulnerable'
-    );
+    const got = runCommand(testsRoot + '/golden/vulnerable');
     const expected = fs.readFileSync(
       testsRoot + '/golden/expected/vulnerable.out',
       'utf8'


### PR DESCRIPTION
Use the same command builder for the test trivy command, we don't need
to be having two different ways of creating the command otherwise we're
not really testing correctly
