### PR TITLE
fix: validate the aqua platform credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 1.0.3
+
+- Validate Aqua Platform settings before setting
+
 ### 1.0.2
 
 - Remove hard coded links to dev env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,27 @@
 {
   "name": "trivy-vulnerability-scanner",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trivy-vulnerability-scanner",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
+        "@types/moment": "^2.11.29",
         "@types/tar": "^6.1.13",
         "@vscode/codicons": "^0.0.36",
         "@vscode/webview-ui-toolkit": "^1.4.0",
+        "crypto-js": "^4.2.0",
         "ignore": "^7.0.3",
+        "moment": "^2.30.1",
         "tar": "^7.4.3",
         "webview-ui-toolkit": "^0.0.0",
         "which": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@types/crypto-js": "^4.2.2",
         "@types/glob": "^7.1.1",
         "@types/mocha": "^7.0.2",
         "@types/node": "^16.0.0",
@@ -797,6 +801,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -868,6 +879,12 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
       "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/moment": {
+      "version": "2.11.29",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.11.29.tgz",
+      "integrity": "sha512-D5WIgbLYQzvgfsDnBhZFSTnt/BjGPOE+Jsh3k1BYYijJAkrn7ceeLvU4jtjKKXXuXN42O3ARlU4D/P9ezbQYFA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3029,6 +3046,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -6238,6 +6261,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "vscode": "^1.56.0"
   },
@@ -276,7 +276,7 @@
       {
         "view": "trivyIssueViewer",
         "contents": "Click the button below to run Trivy against the current workspace.\n[Scan Now](command:trivy.scan)\n\nIf using with Aqua Platform you can use the button below to configure\n[Configure Aqua Platform](command:trivy.setupCommercial)\n",
-        "when": "trivy.extensionLoaded && trivy.installed && trivy.isLatest && !trivy.scanRunning"
+        "when": "trivy.extensionLoaded && trivy.installed &&  !trivy.scanRunning"
       },
       {
         "view": "trivyIssueViewer",
@@ -584,6 +584,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@types/crypto-js": "^4.2.2",
     "@types/glob": "^7.1.1",
     "@types/mocha": "^7.0.2",
     "@types/node": "^16.0.0",
@@ -615,10 +616,13 @@
     "url": "https://github.com/aquasecurity/trivy-vscode-extension"
   },
   "dependencies": {
+    "@types/moment": "^2.11.29",
     "@types/tar": "^6.1.13",
     "@vscode/codicons": "^0.0.36",
     "@vscode/webview-ui-toolkit": "^1.4.0",
+    "crypto-js": "^4.2.0",
     "ignore": "^7.0.3",
+    "moment": "^2.30.1",
     "tar": "^7.4.3",
     "webview-ui-toolkit": "^0.0.0",
     "which": "^5.0.0"

--- a/src/commercial/cred_check.ts
+++ b/src/commercial/cred_check.ts
@@ -1,0 +1,60 @@
+import { HmacSHA256 } from 'crypto-js';
+import moment from 'moment';
+
+export default async function checkCredentialConnection(creds: {
+  apiKey: string;
+  apiSecret: string;
+  aquaUrl: string;
+  cspmUrl: string;
+}): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    try {
+      if (
+        !creds.apiKey ||
+        !creds.apiSecret ||
+        !creds.aquaUrl ||
+        !creds.cspmUrl
+      ) {
+        return reject(new Error('Missing credentials'));
+      }
+
+      if (creds.cspmUrl.endsWith('/')) {
+        creds.cspmUrl = creds.cspmUrl.slice(0, -1);
+      }
+      const body = JSON.stringify({
+        validity: 120,
+        allowed_endpoints: ['ANY:V2/*'],
+      });
+      const requestUrl = `${creds.cspmUrl}/v2/tokens`;
+
+      const timestamp = moment.unix(new Date().getTime() / 1000).valueOf();
+      const someString = timestamp + 'POST' + '/v2/tokens' + body;
+
+      // compute the 256 hmac
+      const hmac = HmacSHA256(someString, creds.apiSecret);
+
+      fetch(requestUrl, {
+        method: 'POST',
+        headers: {
+          'x-signature': hmac.toString(),
+          'x-timestamp': timestamp.toString(),
+          'x-api-key': creds.apiKey,
+        },
+        body: body,
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(
+              `Failed to validate credentials: ${response.statusText}`
+            );
+          }
+          return resolve(true);
+        })
+        .catch((error) => {
+          return reject(error);
+        });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}

--- a/src/commercial/env.ts
+++ b/src/commercial/env.ts
@@ -3,14 +3,6 @@ import * as vscode from 'vscode';
 import { showErrorMessage } from '../notification/notifications';
 
 /**
- * Default service URLs for Aqua Platform
- */
-const AQUA_DEFAULTS = Object.freeze({
-  API_URL: 'https://api.aquasec.com',
-  AUTHENTICATION_URL: 'https://cloud.aquasec.com',
-});
-
-/**
  * Environment variable keys used by Aqua Platform integration
  */
 const ENV_KEYS = Object.freeze({
@@ -61,11 +53,13 @@ export async function updateEnvironment(
     }
 
     // Set environment variables for Aqua Platform integration
-    newEnv[ENV_KEYS.API_URL] =
-      config.get<string>('aquaApiUrl') || AQUA_DEFAULTS.API_URL;
-    newEnv[ENV_KEYS.AUTH_URL] =
-      config.get<string>('aquaAuthenticationUrl') ||
-      AQUA_DEFAULTS.AUTHENTICATION_URL;
+    const aquaApiUrl = config.get<string>('aquaApiUrl');
+    const aquaAuthUrl = config.get<string>('aquaAuthenticationUrl');
+
+    if (aquaApiUrl && aquaAuthUrl) {
+      newEnv[ENV_KEYS.API_URL] = aquaApiUrl;
+      newEnv[ENV_KEYS.AUTH_URL] = aquaAuthUrl;
+    }
     newEnv[ENV_KEYS.API_KEY] = apiKey;
     newEnv[ENV_KEYS.API_SECRET] = apiSecret;
     newEnv[ENV_KEYS.RUN_MODE] = 'aqua';


### PR DESCRIPTION
When saving the configuration for the aqua platform, if the feature is enabled then validate a token against the CSPM url first to ensure that the authentication creds provided are acceptable