### PR TITLE
feat: increase granularity of chosing scanners

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,18 @@
           "default": false,
           "description": "Run Trivy with vebose flag to get more information"
         },
+        "trivy.vulnScanning": {
+          "type": "boolean",
+          "default": true,
+          "description": "Trivy should scan for vulnerabilities",
+          "scope": "window"
+        },
+        "trivy.misconfigScanning": {
+          "type": "boolean",
+          "default": true,
+          "description": "Trivy should scan for misconfigurations",
+          "scope": "window"
+        },
         "trivy.secretScanning": {
           "type": "boolean",
           "default": false,
@@ -189,6 +201,22 @@
         "title": "✓ Offline scanning"
       },
       {
+        "command": "trivy.scanForVulns",
+        "title": "Scan for vulnerabilities"
+      },
+      {
+        "command": "trivy.disableScanForVulns",
+        "title": "✓ Scan for vulnerabilities"
+      },
+      {
+        "command": "trivy.scanForMisconfigs",
+        "title": "Scan for misconfigurations"
+      },
+      {
+        "command": "trivy.disableScanForMisconfigs",
+        "title": "✓ Scan for misconfigurations"
+      },
+      {
         "command": "trivy.scanForSecrets",
         "title": "Scan for secrets"
       },
@@ -322,16 +350,6 @@
           "group": "3_setting@1"
         },
         {
-          "command": "trivy.scanForSecrets",
-          "when": "view == trivyIssueViewer && !trivy.secretScanning",
-          "group": "3_setting@2"
-        },
-        {
-          "command": "trivy.disableScanForSecrets",
-          "when": "view == trivyIssueViewer && trivy.secretScanning",
-          "group": "3_setting@2"
-        },
-        {
           "command": "trivy.onlyFixedIssues",
           "when": "view == trivyIssueViewer && !trivy.fixedOnly",
           "group": "3_setting@3"
@@ -340,6 +358,36 @@
           "command": "trivy.disableOnlyFixedIssues",
           "when": "view == trivyIssueViewer && trivy.fixedOnly",
           "group": "3_setting@3"
+        },
+        {
+          "command": "trivy.scanForVulns",
+          "when": "view == trivyIssueViewer && !trivy.vulnScanning",
+          "group": "3_scanners@1"
+        },
+        {
+          "command": "trivy.disableScanForVulns",
+          "when": "view == trivyIssueViewer && trivy.vulnScanning",
+          "group": "3_scanners@1"
+        },
+        {
+          "command": "trivy.scanForMisconfigs",
+          "when": "view == trivyIssueViewer && !trivy.misconfigScanning",
+          "group": "3_scanners@2"
+        },
+        {
+          "command": "trivy.disableScanForMisconfigs",
+          "when": "view == trivyIssueViewer && trivy.misconfigScanning",
+          "group": "3_scanners@2"
+        },
+        {
+          "command": "trivy.scanForSecrets",
+          "when": "view == trivyIssueViewer && !trivy.secretScanning",
+          "group": "3_scanners@3"
+        },
+        {
+          "command": "trivy.disableScanForSecrets",
+          "when": "view == trivyIssueViewer && trivy.secretScanning",
+          "group": "3_scanners@3"
         },
         {
           "command": "trivy.setupCommercial",

--- a/src/activate_commands.ts
+++ b/src/activate_commands.ts
@@ -185,6 +185,18 @@ export function registerCommands(
   registerCommand(context, 'trivy.disableOfflineScan', () =>
     updateConfigAndContext(config, 'offlineScan', false)
   );
+  registerCommand(context, 'trivy.scanForVulns', () =>
+    updateConfigAndContext(config, 'vulnScanning', true)
+  );
+  registerCommand(context, 'trivy.disableScanForVulns', () =>
+    updateConfigAndContext(config, 'vulnScanning', false)
+  );
+  registerCommand(context, 'trivy.scanForMisconfigs', () =>
+    updateConfigAndContext(config, 'misconfigScanning', true)
+  );
+  registerCommand(context, 'trivy.disableScanForMisconfigs', () =>
+    updateConfigAndContext(config, 'misconfigScanning', false)
+  );
   registerCommand(context, 'trivy.scanForSecrets', () =>
     updateConfigAndContext(config, 'secretScanning', true)
   );

--- a/src/command/options.ts
+++ b/src/command/options.ts
@@ -71,7 +71,15 @@ export class ScannersOption extends ConfigAwareOption {
     command: string[],
     config: vscode.WorkspaceConfiguration
   ): string[] {
-    const scanners = ['misconfig', 'vuln'];
+    const scanners = [];
+
+    if (config.get<boolean>('vulnScanning')) {
+      scanners.push('vuln');
+    }
+
+    if (config.get<boolean>('misconfigScanning')) {
+      scanners.push('misconfig');
+    }
 
     if (config.get<boolean>('secretScanning')) {
       scanners.push('secret');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,8 @@ const disposables: vscode.Disposable[] = [];
 const CONFIG_BOOLEAN_KEYS = [
   'useIgnoreFile',
   'offlineScan',
+  'vulnScanning',
+  'misconfigScanning',
   'secretScanning',
   'fixedOnly',
   'onlyUseConfigFile',

--- a/test/suite/command/options.test.ts
+++ b/test/suite/command/options.test.ts
@@ -41,8 +41,12 @@ suite('trivy command options', function (): void {
     assert.strictEqual(command.join(' '), '--debug');
   });
 
-  test('Trivy scanners command option', () => {
+  test('Trivy scanners command option with all enabled', () => {
     const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
+    config.update('vulnScanning', true);
+    config.update('misconfigScanning', true);
+    config.update('secretScanning', true);
+
     let command: string[] = [];
 
     const commandOption = new ScannersOption();
@@ -50,7 +54,34 @@ suite('trivy command options', function (): void {
 
     assert.strictEqual(
       command.join(' '),
-      '--scanners=misconfig,vuln --list-all-pkgs'
+      '--scanners=vuln,misconfig,secret --list-all-pkgs'
+    );
+  });
+
+  test('Trivy scanners command option with vuln enabled', () => {
+    const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
+    config.update('vulnScanning', true);
+
+    let command: string[] = [];
+
+    const commandOption = new ScannersOption();
+    command = commandOption.apply(command, config);
+
+    assert.strictEqual(command.join(' '), '--scanners=vuln --list-all-pkgs');
+  });
+
+  test('Trivy scanners command option with misconfig enabled', () => {
+    const config = new mockConfig() as unknown as vscode.WorkspaceConfiguration;
+    config.update('misconfigScanning', true);
+
+    let command: string[] = [];
+
+    const commandOption = new ScannersOption();
+    command = commandOption.apply(command, config);
+
+    assert.strictEqual(
+      command.join(' '),
+      '--scanners=misconfig --list-all-pkgs'
     );
   });
 
@@ -63,10 +94,7 @@ suite('trivy command options', function (): void {
     const commandOption = new ScannersOption();
     command = commandOption.apply(command, config);
 
-    assert.strictEqual(
-      command.join(' '),
-      '--scanners=misconfig,vuln,secret --list-all-pkgs'
-    );
+    assert.strictEqual(command.join(' '), '--scanners=secret --list-all-pkgs');
   });
 
   test('Trivy offline scan command option', () => {


### PR DESCRIPTION
- allow the user to chose which scanners to use at a window level. This
  setting is saved in the .vscode folder for the current workspace and
  not globally

![image](https://github.com/user-attachments/assets/98417c07-89d5-498d-9f92-eccf76a5fd0a)

