### PR TITLE
fix: don't upload results to aqua platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.2
+
+- Remove the option to upload the results to the Aqua Platform
+
 ## 1.2.1
 
 - Make order by severity the default view

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "engines": {
     "vscode": "^1.56.0"
   },

--- a/src/commercial/env.ts
+++ b/src/commercial/env.ts
@@ -65,6 +65,10 @@ export async function updateEnvironment(
     newEnv[ENV_KEYS.RUN_MODE] = 'aqua';
     newEnv[ENV_KEYS.ASSURANCE_EXPORT] = `${assuranceReportPath}`;
 
+    // don't upload the results to the aqua platform
+    newEnv['TRIVY_SKIP_REPOSITORY_UPLOAD'] = 'true';
+    newEnv['TRIVY_SKIP_RESULT_UPLOAD'] = 'true';
+
     return newEnv;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/commercial/setup.ts
+++ b/src/commercial/setup.ts
@@ -168,7 +168,6 @@ function getWebviewContent(
   const useAquaPlatform = config.get<boolean>('useAquaPlatform');
   const aquaApiUrl = config.get('aquaApiUrl');
   const aquaAuthenticationUrl = config.get('aquaAuthenticationUrl');
-  const uploadResults = config.get<boolean>('uploadResults');
 
   return /* html */ `
   <!DOCTYPE html>
@@ -243,7 +242,6 @@ function getWebviewContent(
                  Authentication Endpoint
                  <span slot="start" class="codicon codicon-globe"></span>
                  </vscode-text-field><br />
-                 <vscode-checkbox id="uploadResults" name="uploadResults" ${uploadResults ? 'checked' : ''}>Upload Results</vscode-checkbox> <br>
                  <br />
               <vscode-button id="save-button" appearance="primary" type="submit" >Save</vscode-button>
               <!-- <button type="submit">Save</button> -->
@@ -275,7 +273,6 @@ function getWebviewContent(
                const apiUrl = document.getElementById('apiUrl').value;
                const authUrl = document.getElementById('authUrl').value;
                const enableAquaPlatform = document.getElementById('enableAquaPlatform').checked;
-               const uploadResults = document.getElementById('uploadResults').checked;
                vscode.postMessage({ command: 'storeSecrets', apiKey, apiSecret, apiUrl, authUrl, enableAquaPlatform, uploadResults });
            });
         </script>

--- a/src/explorer/treeview/treeitem.ts
+++ b/src/explorer/treeview/treeitem.ts
@@ -91,21 +91,11 @@ export class TrivyTreeItem extends vscode.TreeItem {
       case TrivyTreeItemType.secretCode:
         this.tooltip = this.id;
         this.iconPath = {
-          light: path.join(
-            __filename,
-            '..',
-            '..',
-            'resources',
-            'light',
-            'key.svg'
+          light: vscode.Uri.file(
+            path.join(__filename, '..', '..', 'resources', 'light', 'key.svg')
           ),
-          dark: path.join(
-            __filename,
-            '..',
-            '..',
-            'resources',
-            'dark',
-            'key.svg'
+          dark: vscode.Uri.file(
+            path.join(__filename, '..', '..', 'resources', 'dark', 'key.svg')
           ),
         };
         break;


### PR DESCRIPTION
We never want to send the results of a run to the aqua platform, so this
can be removed from the UI and the env settings

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
