### PR TITLE
feat: add command to install MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ From the menu, select `Trivy Aqua Platform Integration` and provide your Aqua de
 
 Now run a scan as normal and you will have additional policy results.
 
+## Installing the Trivy MCP Server
+
+Trivy has an MCP Server that is compatible with VS Code. The MCP Server can be configured from this extension by pressing `F1` then searching for `Install Trivy MCP Server`
+
+The version of VS Code must be at least v1.99.0 - this was when MCP Server support was added.
+
+The installation process will:
+
+- install the `mcp` plugin for Trivy using `trivy plugin install mcp`
+- ensure that `chat.agent.enabled` and `chat.mcp.discovery.enabled` are both `true` in the settings
+- add a `trivy` mcp server if it isn't already present in the settings
+- open the `settings.json` to show the changes that have been made
+
+For more details about the Trivy MCP Server, check the MCP repo [README.md](https://github.com/aquasecurity/trivy-mcp/blob/main/README.md)
+
 ## Known Issues
 
 If you find one, please file a GitHub Issue [here](https://github.com/aquasecurity/trivy-vscode-extension/issues/new).

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [
-    "onStartupFinished"
-  ],
+  "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "configuration": {
@@ -649,6 +651,10 @@
         {
           "command": "trivy.useIgnoreFile",
           "when": "false"
+        },
+        {
+          "command": "trivy.installMcpServer",
+          "when": "trivy.mcpSupported"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -164,6 +164,10 @@
         "title": "Update Trivy"
       },
       {
+        "command": "trivy.installMcpServer",
+        "title": "Install Trivy MCP Server"
+      },
+      {
         "command": "trivy.scan",
         "title": "Trivy: Run trivy against workspace",
         "icon": {

--- a/src/activate_commands.ts
+++ b/src/activate_commands.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { TrivyWrapper } from './command/command';
 import { installTrivy } from './command/install';
 import { setupCommercial } from './commercial/setup';
+import { installTrivyMCPServer } from './mcp/install';
 import { TrivyHelpProvider } from './ui/helpview/helpview';
 import { showErrorMessage } from './ui/notification/notifications';
 import { TrivyTreeViewProvider } from './ui/treeview/treeview_provider';
@@ -140,6 +141,15 @@ export function registerCommands(
       await installTrivy(context.extensionPath, true);
     },
     'Failed to install Trivy'
+  );
+
+  registerCommand(
+    context,
+    'trivy.installMcpServer',
+    async () => {
+      await installTrivyMCPServer();
+    },
+    'Failed to install Trivy MCP server'
   );
 
   // Scanning commands

--- a/src/command/command.ts
+++ b/src/command/command.ts
@@ -136,6 +136,10 @@ export class TrivyWrapper {
     }
   }
 
+  /**
+   * Check if Trivy is installed
+   * @returns Promise resolving to true if installed, false otherwise
+   */
   async isInstalled(): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,6 +247,14 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
     const configVal = config.get<boolean>(key, false);
     vscode.commands.executeCommand('setContext', `trivy.${key}`, configVal);
   });
+
+  // Update the version specific context
+  const vscodeVersion = vscode.version;
+  const minorVersion = parseInt(vscodeVersion.split('.')[1], 10);
+  if (minorVersion >= 99) {
+    // MCP Server support added in VS Code 1.99
+    vscode.commands.executeCommand('setContext', 'trivy.mcpSupported', true);
+  }
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,8 +250,9 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
 
   // Update the version specific context
   const vscodeVersion = vscode.version;
+  const majorVersion = parseInt(vscodeVersion.split('.')[0], 10);
   const minorVersion = parseInt(vscodeVersion.split('.')[1], 10);
-  if (minorVersion >= 99) {
+  if (majorVersion > 1 || (majorVersion === 1 && minorVersion >= 99)) {
     // MCP Server support added in VS Code 1.99
     vscode.commands.executeCommand('setContext', 'trivy.mcpSupported', true);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -252,10 +252,13 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
   const vscodeVersion = vscode.version;
   const majorVersion = parseInt(vscodeVersion.split('.')[0], 10);
   const minorVersion = parseInt(vscodeVersion.split('.')[1], 10);
-  if (majorVersion > 1 || (majorVersion === 1 && minorVersion >= 99)) {
-    // MCP Server support added in VS Code 1.99
-    vscode.commands.executeCommand('setContext', 'trivy.mcpSupported', true);
-  }
+  const mcpSupported = majorVersion >= 1 && minorVersion >= 99;
+  // MCP Server support added in VS Code 1.99
+  vscode.commands.executeCommand(
+    'setContext',
+    'trivy.mcpSupported',
+    mcpSupported
+  );
 }
 
 /**

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -1,0 +1,110 @@
+import * as child from 'child_process';
+
+import * as vscode from 'vscode';
+
+import { Output } from '../command/output';
+import { openSettingsJsonAtSection } from '../utils';
+
+export async function installTrivyMCPServer(): Promise<void> {
+  Output.show();
+
+  const trivyConfig = vscode.workspace.getConfiguration('trivy');
+  const trivyBinary = trivyConfig.get<string>('binaryPath', 'trivy');
+
+  // make required changes to chat config
+  const chatConfig = vscode.workspace.getConfiguration('chat');
+  const agentEnabled = chatConfig.get<boolean>('agent.enabled', false);
+  if (!agentEnabled) {
+    Output.getInstance().appendLineWithTimestamp(
+      'Enabling the agent in chat configuration to allow Trivy MCP server installation.'
+    );
+    // Enable the agent if it is not already enabled
+    await chatConfig.update(
+      'agent.enabled',
+      true,
+      vscode.ConfigurationTarget.Global
+    );
+  }
+
+  const mcpDiscoveryEnabled = chatConfig.get<boolean>(
+    'mcp.discovery.enabled',
+    false
+  );
+  if (!mcpDiscoveryEnabled) {
+    Output.getInstance().appendLineWithTimestamp(
+      'Enabling MCP discovery in chat configuration to allow Trivy MCP server installation.'
+    );
+    // Enable MCP discovery if it is not already enabled
+    await chatConfig.update(
+      'mcp.discovery.enabled',
+      true,
+      vscode.ConfigurationTarget.Global
+    );
+  }
+
+  const mcpServers = vscode.workspace
+    .getConfiguration('mcp')
+    .get('servers') as Record<string, object>;
+  if (!mcpServers || typeof mcpServers !== 'object') {
+    Output.getInstance().appendLineWithTimestamp(
+      'No MCP servers configured. Initializing with an empty object.'
+    );
+  }
+
+  // Ensure trivy plugin installed
+  const pluginInstalled = await installPlugin(trivyBinary);
+  if (!pluginInstalled) {
+    Output.getInstance().appendLineWithTimestamp(
+      'Trivy plugin is not installed. Please install it before configuring the MCP server.'
+    );
+    return; // Exit if plugin is not installed
+  }
+
+  for (const server of Object.keys(mcpServers as Record<string, unknown>)) {
+    if (server.toLocaleLowerCase() === 'trivy') {
+      Output.getInstance().appendLineWithTimestamp(
+        'Trivy MCP server is already configured.'
+      );
+      return; // Trivy MCP server is already configured
+    }
+  }
+
+  mcpServers['trivy'] = {
+    type: 'stdio',
+    command: 'trivy',
+    args: ['mcp', '--trivy-binary', trivyBinary],
+  };
+
+  await vscode.workspace
+    .getConfiguration('mcp')
+    .update('servers', mcpServers, vscode.ConfigurationTarget.Global);
+
+  Output.getInstance().appendLineWithTimestamp(
+    'Trivy MCP server has been successfully installed and configured.'
+  );
+
+  // Open the user configuration file to show the changes
+  await openSettingsJsonAtSection('mcp.servers');
+}
+
+/**
+ * Check if Trivy is installed
+ * @returns Promise resolving to true if installed, false otherwise
+ */
+async function installPlugin(binary: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    try {
+      Output.getInstance().appendLineWithTimestamp('Installing MCP Plugin');
+      child.execSync(`"${binary}" plugin install mcp`, { stdio: 'ignore' });
+      Output.getInstance().appendLineWithTimestamp(
+        'MCP Plugin installed successfully.'
+      );
+      resolve(true);
+    } catch (error) {
+      Output.getInstance().appendLineWithTimestamp(
+        `Failed to install MCP Plugin: ${error instanceof Error ? error.message : String(error)}`
+      );
+      resolve(false);
+    }
+  });
+}

--- a/src/mcp/install.ts
+++ b/src/mcp/install.ts
@@ -42,13 +42,18 @@ export async function installTrivyMCPServer(): Promise<void> {
     );
   }
 
-  const mcpServers = vscode.workspace
+  let mcpServers = vscode.workspace
     .getConfiguration('mcp')
     .get('servers') as Record<string, object>;
   if (!mcpServers || typeof mcpServers !== 'object') {
     Output.getInstance().appendLineWithTimestamp(
       'No MCP servers configured. Initializing with an empty object.'
     );
+    // Initialize mcpServers if it is not defined or not an object
+    await vscode.workspace
+      .getConfiguration('mcp')
+      .update('servers', {}, vscode.ConfigurationTarget.Global);
+    mcpServers = {};
   }
 
   // Ensure trivy plugin installed
@@ -88,7 +93,7 @@ export async function installTrivyMCPServer(): Promise<void> {
 }
 
 /**
- * Check if Trivy is installed
+ * Installs the MCP plugin for Trivy
  * @returns Promise resolving to true if installed, false otherwise
  */
 async function installPlugin(binary: string): Promise<boolean> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,6 +176,12 @@ export async function openSettingsAtSection(settingId: string): Promise<void> {
   );
 }
 
+/**
+ * Opens the settings JSON file at a specific section
+ * This is useful for advanced users who want to edit settings directly in JSON format.
+ * @param settingId The setting ID to focus on (e.g., "trivy.vulnScanning" or "mcp.servers")
+ * @returns A promise that resolves when the command is executed
+ */
 export async function openSettingsJsonAtSection(
   settingId: string
 ): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,3 +163,24 @@ export function getSafeResultsPath(
 
   return p;
 }
+
+/**
+ * Opens VS Code settings UI at a specified setting
+ * @param settingId The setting ID to focus on (e.g., "trivy.vulnScanning" or "mcp.servers")
+ * @returns A promise that resolves when the command is executed
+ */
+export async function openSettingsAtSection(settingId: string): Promise<void> {
+  return vscode.commands.executeCommand(
+    'workbench.action.openSettings',
+    settingId
+  );
+}
+
+export async function openSettingsJsonAtSection(
+  settingId: string
+): Promise<void> {
+  return vscode.commands.executeCommand(
+    'workbench.action.openSettingsJson',
+    settingId
+  );
+}


### PR DESCRIPTION
Add a command that will install the MCP Server for Trivy in the user
settings and ensure that the plugin has been installed.

Signed-off-by: Owen Rumney <owen.rumney@aquasec.com>
