### PR TITLE
fix: ensure problems are cleared on scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.1
+
+- Fix bug to ensure that problems are cleared on every scan
+
 ## 1.8.0
 
 - Add support for SAST when using the Aqua Platform scan

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "engines": {
     "vscode": "^1.56.0"
   },

--- a/src/ui/treeview/problems.ts
+++ b/src/ui/treeview/problems.ts
@@ -19,6 +19,8 @@ export class Problems {
   }
 
   public updateProblems(trivyResults: TrivyResult[]) {
+    //always clear problems before updating
+    this.clearProblems();
     if (trivyResults.length === 0) {
       return;
     }

--- a/src/ui/treeview/treeview_provider.ts
+++ b/src/ui/treeview/treeview_provider.ts
@@ -87,6 +87,7 @@ export class TrivyTreeViewProvider
     // this.taintResults = true;
     this.resultData.clear();
     this._onDidChangeTreeData.fire();
+    Problems.instance.clearProblems();
   }
 
   /**


### PR DESCRIPTION
When a reset or a scan is triggered, Problems pane for "trivy" needs to
be cleared.
