### PR TITLE
fix: Ensure the custom URL fields get enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.3
+
+- Fix an issue when using custom URL for the Aqua Platform
+
 ## 1.8.2
 
 - Add envvar to report to Aqua Platform the source of the request

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "engines": {
     "vscode": "^1.56.0"
   },

--- a/src/commercial/setup.ts
+++ b/src/commercial/setup.ts
@@ -343,6 +343,8 @@ function getWebviewContent(
                 document.getElementById('apiKey').disabled = !checked;
                 document.getElementById('apiSecret').disabled = !checked;
                 document.getElementById('aqua-platform-region').disabled = !checked;
+                document.getElementById('customApiUrl').disabled = !checked;
+                document.getElementById('custonAuthUrl').disabled = !checked;
                 const regionLabel = document.getElementById('region-label');
                 if (!checked) {
                     regionLabel.classList.add('disabled');


### PR DESCRIPTION
When the custom region is used, ensure that the event handler also
enables the custom region url input fields

Closes #123
