### PR TITLE
fix: windows 64bit install checksum issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.4
+
+- Fix issues with install 64bit version of trivy on Windows
+
 ## 1.8.3
 
 - Fix an issue when using custom URL for the Aqua Platform

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "engines": {
     "vscode": "^1.56.0"
   },

--- a/src/command/install.ts
+++ b/src/command/install.ts
@@ -86,7 +86,7 @@ function getPlatformInfo(): { os: string; arch: string } {
 
   switch (arch) {
     case 'x64':
-      archName = 'AMD64';
+      archName = '64bit';
       break;
     case 'arm64':
       archName = 'ARM64';


### PR DESCRIPTION
Fix an issue with the installtion of trivy through the IDE when on a
64bit windows machine. Previously the checksum for AMD64 was being
checked for but its 64bit
