### PR TITLE
feat: Add menu to add MCP prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,10 @@
         "title": "Install Trivy MCP Server"
       },
       {
+        "command": "trivy.mcpAddCodePrompt",
+        "title": "Add MCP Code Prompt"
+      },
+      {
         "command": "trivy.scan",
         "title": "Run trivy against workspace",
         "icon": {
@@ -328,10 +332,6 @@
         "title": "✓ Use Aqua Platform"
       },
       {
-        "command": "trivy.update",
-        "title": "Update Trivy"
-      },
-      {
         "command": "trivy.addToIgnoreFile",
         "title": "Add to Trivy ignore file"
       }
@@ -402,12 +402,12 @@
         {
           "command": "trivy.reset",
           "when": "view == trivyIssueViewer",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "submenu": "trivyIgnoreMenu",
           "when": "view == trivyIssueViewer && !trivy.useAquaPlatform",
-          "group": "1_ignore"
+          "group": "1_ignore@1"
         },
         {
           "submenu": "trivyConfigMenu",
@@ -520,6 +520,11 @@
           "group": "4_aquaPlatform"
         },
         {
+          "submenu": "trivyMcpMenu",
+          "when": "view == trivyIssueViewer && trivy.mcpServerInstalled",
+          "group": "5_trivyMcp@1"
+        },
+        {
           "command": "trivy.version",
           "when": "view == trivyIssueViewer",
           "group": "5_version"
@@ -544,6 +549,13 @@
         {
           "command": "trivy.addToIgnoreFile",
           "when": "view == trivyIssueViewer && viewItem == trivy.ignorable"
+        }
+      ],
+      "trivyMcpMenu": [
+        {
+          "command": "trivy.mcpAddCodePrompt",
+          "description": "Add a helpful code completion prompt to run Trivy when some actions are performed by the agent",
+          "group": "1_mcp@1"
         }
       ],
       "trivyConfigMenu": [
@@ -747,6 +759,10 @@
       {
         "id": "trivyConfigMenu",
         "label": "Config File"
+      },
+      {
+        "id": "trivyMcpMenu",
+        "label": "Trivy MCP Server"
       }
     ],
     "walkthroughs": [

--- a/src/activate_commands.ts
+++ b/src/activate_commands.ts
@@ -5,7 +5,7 @@ import { TrivyWrapper } from './command/command';
 import { installTrivy } from './command/install';
 import { setupCommercial } from './commercial/setup';
 import { addIgnoreFileEntry } from './ignore/ignore_file';
-import { installTrivyMCPServer } from './mcp/install';
+import { addMCPCodePrompt, installTrivyMCPServer } from './mcp/install';
 import { TrivyHelpProvider } from './ui/helpview/helpview';
 import { showErrorMessage } from './ui/notification/notifications';
 import { TrivyTreeItem } from './ui/treeview/treeitem';
@@ -153,6 +153,10 @@ export function registerCommands(
     },
     'Failed to install Trivy MCP server'
   );
+
+  registerCommand(context, 'trivy.mcpAddCodePrompt', async () => {
+    await addMCPCodePrompt();
+  });
 
   // Scanning commands
   registerCommand(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { registerCommands } from './activate_commands';
 import { TrivyWrapper } from './command/command';
 import { verifyTrivyInstallation } from './command/install';
 import { Output } from './command/output';
+import { isTrivyMCPInstalled } from './mcp/install';
 import { VulnerabilityCodeLensProvider } from './ui/codelens_provider';
 import { TrivyHelpProvider } from './ui/helpview/helpview';
 import { showErrorMessage } from './ui/notification/notifications';
@@ -259,6 +260,13 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
     'setContext',
     'trivy.mcpSupported',
     mcpSupported
+  );
+
+  const trivyMcpInstalled = isTrivyMCPInstalled();
+  vscode.commands.executeCommand(
+    'setContext',
+    'trivy.mcpServerInstalled',
+    trivyMcpInstalled
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,10 +183,8 @@ export async function openSettingsAtSection(settingId: string): Promise<void> {
  * @returns A promise that resolves when the command is executed
  */
 export async function openSettingsJsonAtSection(
-  settingId: string
+  settingId: string,
+  settingsOpenAction = 'workbench.action.openSettingsJson'
 ): Promise<void> {
-  return vscode.commands.executeCommand(
-    'workbench.action.openSettingsJson',
-    settingId
-  );
+  return vscode.commands.executeCommand(settingsOpenAction, settingId);
 }


### PR DESCRIPTION
Add a menu item to install the Trivy MCP coding prompt when Trivy MCP
has been installed as a server.

The Trivy MCP Server menu is only added when the MCP Server is enabled.

Closes #128 
