### PR TITLE
feat: detect Cursor to enable MCP server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,6 +15,15 @@
       "preLaunchTask": "npm: build:dev"
     },
     {
+      "name": "Run Extension (Cursor)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "cursor", // if the `cursor` CLI is on PATH
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"]
+    },
+
+    {
       "name": "Extension Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.5
+
+- Add support for detecting cursor to enable MCP menu
+
 ## 1.8.4
 
 - Fix issues with install 64bit version of trivy on Windows

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "engines": {
     "vscode": "^1.56.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,11 +250,14 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
     vscode.commands.executeCommand('setContext', `trivy.${key}`, configVal);
   });
 
+  const appName = vscode.env.appName.toLowerCase();
+  const isCursor = appName.includes('cursor');
+
   // Update the version specific context
   const vscodeVersion = vscode.version;
   const majorVersion = parseInt(vscodeVersion.split('.')[0], 10);
   const minorVersion = parseInt(vscodeVersion.split('.')[1], 10);
-  const mcpSupported = majorVersion >= 1 && minorVersion >= 99;
+  const mcpSupported = isCursor || (majorVersion >= 1 && minorVersion >= 99);
   // MCP Server support added in VS Code 1.99
   vscode.commands.executeCommand(
     'setContext',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,7 +251,7 @@ function syncContextWithConfig(config: vscode.WorkspaceConfiguration): void {
   });
 
   const appName = vscode.env.appName.toLowerCase();
-  const isCursor = appName.includes('cursor');
+  const isCursor = appName === 'cursor';
 
   // Update the version specific context
   const vscodeVersion = vscode.version;


### PR DESCRIPTION
When running in Cursor we want to detect that so the `mcpSupported`
context flag can be set accordingly and enable the Trivy installation
menu
