### PR TITLE
feat: Add menu option to update Aqua plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.6
+
+- Add a menu option to update the version of the Aqua plugin
+
 ## 1.8.5
 
 - Add support for detecting cursor to enable MCP menu

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "engines": {
     "vscode": "^1.56.0"
   },
@@ -328,6 +328,10 @@
         "title": "Use Aqua Platform"
       },
       {
+        "command": "trivy.updateAquaPlugin",
+        "title": "Update Aqua Platform Plugin"
+      },
+      {
         "command": "trivy.disableUseAquaPlatform",
         "title": "✓ Use Aqua Platform"
       },
@@ -513,6 +517,11 @@
           "command": "trivy.disableSastScanning",
           "when": "view == trivyIssueViewer && trivy.sastScanning && trivy.useAquaPlatform",
           "group": "4_aquaPlatform@7"
+        },
+        {
+          "command": "trivy.updateAquaPlugin",
+          "when": "view == trivyIssueViewer && trivy.useAquaPlatform",
+          "group": "4_aquaPlatform@8"
         },
         {
           "command": "trivy.setupCommercial",

--- a/src/activate_commands.ts
+++ b/src/activate_commands.ts
@@ -177,6 +177,12 @@ export function registerCommands(
     () => trivyWrapper.showCurrentTrivyVersion(),
     'Failed to get Trivy version'
   );
+  registerCommand(
+    context,
+    'trivy.updateAquaPlugin',
+    () => trivyWrapper.updateAquaPlugin(),
+    'Failed to update aqua plugin'
+  );
   registerCommand(context, 'trivy.refresh', () => {
     misconfigProvider.refresh();
     assuranceProvider.refresh();


### PR DESCRIPTION
When Aqua platform integration is enabled we want to provide a mechanism
for updating the aqua plugin.

When the platform is enabled, a menu item is available to update the
plugin, it will open the output window and run `trivy plugin upgrade
aqua`
