### PR TITLE
feat: add CA support for proxy in aqua plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ contrib
 trivy
 trivy.exe
 .vscode/settings.json
+cert.pem
+key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.8.9
+
+- Add support for custom proxy server and CA certificate provision
+
 ## 1.8.8
 
 - Add skip directories with defaults that can be overridden in the workspace

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "AquaSecurityOfficial",
   "description": "Find vulnerabilities, misconfigurations and exposed secrets in your code",
   "icon": "images/icon.png",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "engines": {
     "vscode": "^1.56.0"
   },
@@ -142,6 +142,16 @@
           "type": "string",
           "default": "",
           "description": "Aqua API URL"
+        },
+        "trivy.proxyServer": {
+          "type": "string",
+          "default": "",
+          "description": "HTTP/HTTPS proxy server URL for Aqua Platform communication (format: http://proxy-host:port or https://proxy-host:port)"
+        },
+        "trivy.caCertPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to CA Cert file for Aqua Platform communication"
         },
         "trivy.useAquaPlatform": {
           "type": "boolean",

--- a/src/commercial/env.ts
+++ b/src/commercial/env.ts
@@ -19,6 +19,9 @@ const ENV_KEYS = Object.freeze({
   TRIVY_SKIP_REPOSITORY_UPLOAD: 'TRIVY_SKIP_REPOSITORY_UPLOAD',
   TRIVY_SKIP_RESULT_UPLOAD: 'TRIVY_SKIP_RESULT_UPLOAD',
   TRIVY_IDE_IDENTIFIER: 'TRIVY_IDE_IDENTIFIER',
+  CA_CERT: 'CA_CERT',
+  HTTP_PROXY: 'HTTP_PROXY',
+  HTTPS_PROXY: 'HTTPS_PROXY',
 });
 
 /**
@@ -62,6 +65,16 @@ export async function updateEnvironment(
     // Set environment variables for Aqua Platform integration
     const aquaApiUrl = config.get<string>('aquaApiUrl');
     const aquaAuthUrl = config.get<string>('aquaAuthenticationUrl');
+
+    const proxyServer = config.get<string>('proxyServer');
+    if (proxyServer) {
+      newEnv[ENV_KEYS.HTTP_PROXY] = proxyServer;
+      newEnv[ENV_KEYS.HTTPS_PROXY] = proxyServer;
+    }
+    const caCertPath = config.get<string>('caCertPath');
+    if (caCertPath) {
+      newEnv[ENV_KEYS.CA_CERT] = caCertPath;
+    }
 
     if (aquaApiUrl && aquaAuthUrl) {
       newEnv[ENV_KEYS.API_URL] = aquaApiUrl;


### PR DESCRIPTION
The commercial trivy plugin supports providing a proxy and a CA
certificate. This is now configurable through the "Configure Aqua
Platform" webview.

When the proxy has a value it will be set, same with the CA Cert.

Closes #142
