### PR TITLE
ci: Security hardening for GitHub Actions workflows (Permissions, SHA pinning, Injection prevention)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,12 +3,20 @@ name: check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 23.x
           cache: npm

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,30 +3,35 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 23.x
           cache: npm
 
       - run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${{ github.ref_name }}"
           # Remove 'v' prefix from tag if present
-          TAG_VERSION=${TAG_VERSION#v}
+          TAG_VERSION_CLEAN="${TAG_VERSION#v}"
 
           echo "Package version: $PKG_VERSION"
-          echo "Tag version: $TAG_VERSION"
+          echo "Tag version: $TAG_VERSION_CLEAN"
 
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Error: Version mismatch between package.json ($PKG_VERSION) and git tag ($TAG_VERSION)"
+          if [ "$PKG_VERSION" != "$TAG_VERSION_CLEAN" ]; then
+            echo "Error: Version mismatch between package.json ($PKG_VERSION) and git tag ($TAG_VERSION_CLEAN)"
             exit 1
           fi
-          echo "✅ Version check passed"
+          echo "Version check passed"
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
       - run: npm ci
       - run: npm run build
       - run: npm run package

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,20 +5,28 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 23
 
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.2
+        uses: aquasecurity/setup-trivy@ff1b8b060f23b650436d419b5e13f67f5d4c3087 # v0.2.2
 
       - name: Install npm dependencies
         run: npm install


### PR DESCRIPTION
Description:

Hi team! 👋

In light of recent industry focus on VS Code extension supply chains, I performed an audit of this repository's GitHub Actions workflows. I've implemented a series of security hardening measures based on GitHub's official Security Best Practices. This PR introduces no functional changes to the CI/CD pipeline. It strictly enforces least-privilege and immutability.

**Security Hardening Implemented:**

- **Explicit Permissions (High Priority):** Added `permissions: contents: read` to all workflows. This ensures the GITHUB_TOKEN defaults to read-only, preventing a compromised third-party action from using the default token to modify repository contents.

- **Immutable Action SHAs (Medium Priority):** Pinned all third-party and first-party actions to their specific commit SHAs. This mitigates the risk of a malicious actor force-pushing a compromised update to a mutable release tag.

- **Shell Injection Prevention (Medium Priority):** In `publish.yaml`, moved the `${{ github.ref_name }}` context variable into an `env:` block before shell execution. This prevents script injection if the context is ever used in a more dangerous trigger context.

- **Resource Optimization (Low Priority):** Added `timeout-minutes: 15` to prevent malicious PRs from draining Actions minutes, and added concurrency groups to cancel redundant CI runs.

All workflows have been validated locally and on a test fork. Let me know if you need any adjustments!
